### PR TITLE
[fix] 修复旧版 RT-Thread 没有 RT_SENSOR_VENDOR_DALLAS 宏定义的问题

### DIFF
--- a/sensor_dallas_dht11.c
+++ b/sensor_dallas_dht11.c
@@ -36,6 +36,10 @@
 #error "Please enable RT_USING_PIN"
 #endif
 
+#ifndef RT_SENSOR_VENDOR_DALLAS
+#define RT_SENSOR_VENDOR_DALLAS (7u)
+#endif
+
 #ifndef rt_hw_us_delay
 RT_WEAK void rt_hw_us_delay(rt_uint32_t us)
 {


### PR DESCRIPTION
[fix] 修复旧版 RT-Thread 没有 RT_SENSOR_VENDOR_DALLAS 宏定义的问题

关联 issue #1 

Signed-off-by: MurphyZhao <d2014zjt@163.com>