### PR TITLE
[sensor] sensor mode separation

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -6,10 +6,13 @@ cwd = GetCurrentDir()
 src = []
 inc = [cwd]
 
-src += ['sensor_dallas_dht11.c']
+src += ['rt_hw_dht11.c']
 
 if GetDepend(['PKG_USING_DHT11_SAMPLE']):
     src += ['dht11_sample.c']
+
+if GetDepend('PKG_DHT11_USING_SENSOR_V1'):
+    src += ['sensor_dallas_dht11.c']
 
 group = DefineGroup('dht11', src, depend = ['PKG_USING_DHT11'], CPPPATH = inc)
 Return('group')

--- a/rt_hw_dht11.c
+++ b/rt_hw_dht11.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2006-2024, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author          Notes
+ * 2019-08-01     LuoGong         the first version.
+ * 2019-08-15     MurphyZhao      add lock and modify code style
+ * 2024-07-02     KurisaW         sensor mode separation
+ *
+ */
+
+#include <rtdevice.h>
+#include <rthw.h>
+#include "board.h"
+#include <stdint.h>
+#include "rt_hw_dht11.h"
+
+#define SENSOR_DEBUG
+#define DBG_TAG               "sensor.dht11"
+
+#ifdef SENSOR_DEBUG
+#define DBG_LVL               DBG_LOG
+#else
+#define DBG_LVL               DBG_ERROR
+#endif /* SENSOR_DEBUG */
+#include <rtdbg.h>
+
+#ifndef RT_USING_PIN
+#error "Please enable RT_USING_PIN"
+#endif
+
+#ifndef rt_hw_us_delay
+rt_weak void rt_hw_us_delay(rt_uint32_t us)
+{
+    rt_uint32_t delta;
+
+    us = us * (SysTick->LOAD / (1000000 / RT_TICK_PER_SECOND));
+    delta = SysTick->VAL;
+
+    while (delta - SysTick->VAL < us) continue;
+}
+#endif
+
+static void dht11_reset(rt_base_t pin)
+{
+    rt_pin_mode(pin, PIN_MODE_OUTPUT);
+
+    rt_pin_write(pin, PIN_LOW);
+    rt_thread_mdelay(20);               /* 20ms */
+
+    rt_pin_write(pin, PIN_HIGH);
+    rt_hw_us_delay(30);                 /* 30us*/
+}
+
+static uint8_t dht11_check(rt_base_t pin)
+{
+    uint8_t retry = 0;
+    rt_pin_mode(pin, PIN_MODE_INPUT);
+
+    while (rt_pin_read(pin) && retry < 100)
+    {
+        retry++;
+        rt_hw_us_delay(1);
+    }
+
+    if(retry >= 100)
+    {
+        return CONNECT_FAILED;
+    }
+
+    retry = 0;
+    while (!rt_pin_read(pin) && retry < 100)
+    {
+        retry++;
+        rt_hw_us_delay(1);
+    };
+
+    if(retry >= 100)
+    {
+        return CONNECT_FAILED;
+    }
+
+    return CONNECT_SUCCESS;
+}
+
+static uint8_t dht11_read_bit(rt_base_t pin)
+{
+	uint8_t retry = 0;
+	while (rt_pin_read(pin) && retry < 100)
+    {
+        retry++;
+        rt_hw_us_delay(1);
+    }
+	retry = 0;
+
+	while (!rt_pin_read(pin) && retry < 100)
+    {
+        retry++;
+        rt_hw_us_delay(1);
+    }
+
+	rt_hw_us_delay(40);
+	if(rt_pin_read(pin))
+		return 1;
+    return 0;
+}
+
+static uint8_t dht11_read_byte(rt_base_t pin)
+{
+    uint8_t i, dat = 0;
+
+    for (i = 1; i <= 8; i++)
+    {
+        dat <<= 1;
+		dat |= dht11_read_bit(pin);
+    }
+
+    return dat;
+}
+
+uint8_t dht11_read_Data(rt_base_t pin,uint8_t *temp,uint8_t *humi)
+{
+	uint8_t i, buf[5];
+	dht11_reset(pin);
+
+	if(dht11_check(pin) == 0)
+	{
+		for(i=0; i<5; i++) /* read 40 bits */
+		{
+			buf[i] = dht11_read_byte(pin);
+		}
+
+		if((buf[0] + buf[1] + buf[2] + buf[3]) == buf[4])
+		{
+			*humi = buf[0];
+			*temp = buf[2];
+		}
+	}
+    else
+    {
+        return 1;
+    }
+
+	return 0;	
+}
+
+uint8_t dht11_init(rt_base_t pin)
+{
+    uint8_t ret = 0;
+
+    dht11_reset(pin);
+    ret = dht11_check(pin);
+    if (ret != 0)
+    {
+        dht11_reset(pin);
+        ret = dht11_check(pin);
+    }
+
+    return ret;
+}
+
+int32_t dht11_get_temperature(rt_base_t pin)
+{
+    static int32_t temOLD = 0;
+    uint8_t humi=0, temp = 0;
+    int32_t temNEW;
+
+    dht11_read_Data(pin, &temp, &humi);
+
+    temNEW = (humi << 16)|(temp<<0);
+
+    if((temNEW != temOLD) && (temNEW !=0))
+    {
+        temOLD = temNEW;
+    }
+    return temOLD;
+}

--- a/rt_hw_dht11.h
+++ b/rt_hw_dht11.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2006-2024, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author          Notes
+ * 2019-08-01     LuoGong         the first version.
+ * 2019-08-15     MurphyZhao      add lock and modify code style
+ * 2024-07-02     KurisaW         sensor mode separation
+ *
+ */
+
+#ifndef __RT_HW_DHT11_H__
+#define __RT_HW_DHT11_H__
+
+#include <rtthread.h>
+
+#define CONNECT_SUCCESS  0
+#define CONNECT_FAILED   1
+
+uint8_t dht11_init(rt_base_t pin);
+uint8_t dht11_read_Data(rt_base_t pin,uint8_t *temp,uint8_t *humi);
+int32_t dht11_get_temperature(rt_base_t pin);
+
+#endif /* __RT_HW_DHT11_H__ */

--- a/sensor_dallas_dht11.c
+++ b/sensor_dallas_dht11.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2018, RT-Thread Development Team
+ * Copyright (c) 2006-2024, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -7,15 +7,12 @@
  * Date           Author          Notes
  * 2019-08-01     LuoGong         the first version.
  * 2019-08-15     MurphyZhao      add lock and modify code style
+ * 2024-07-02     KurisaW         sensor mode separation
  *
  */
 
+#include "rt_hw_dht11.h"
 #include "sensor_dallas_dht11.h"
-#include <rtdevice.h>
-#include <rthw.h>
-#include "sensor.h"
-#include "board.h"
-#include <stdint.h>
 
 #define SENSOR_DEBUG
 #define DBG_TAG               "sensor.dht11"
@@ -32,160 +29,9 @@
 #define SENSOR_HUMI_RANGE_MAX (100)
 #define SENSOR_HUMI_RANGE_MIN (0)
 
-#ifndef RT_USING_PIN
-#error "Please enable RT_USING_PIN"
-#endif
-
 #ifndef RT_SENSOR_VENDOR_DALLAS
 #define RT_SENSOR_VENDOR_DALLAS (7u)
 #endif
-
-#ifndef rt_hw_us_delay
-RT_WEAK void rt_hw_us_delay(rt_uint32_t us)
-{
-    rt_uint32_t delta;
-
-    us = us * (SysTick->LOAD / (1000000 / RT_TICK_PER_SECOND));
-    delta = SysTick->VAL;
-
-    while (delta - SysTick->VAL < us) continue;
-}
-#endif
-
-static void dht11_reset(rt_base_t pin)
-{
-    rt_pin_mode(pin, PIN_MODE_OUTPUT);
-
-    rt_pin_write(pin, PIN_LOW);
-    rt_thread_mdelay(20);               /* 20ms */
-
-    rt_pin_write(pin, PIN_HIGH);
-    rt_hw_us_delay(30);                 /* 30us*/
-}
-
-static uint8_t dht11_check(rt_base_t pin)
-{
-    uint8_t retry = 0;
-    rt_pin_mode(pin, PIN_MODE_INPUT);
-
-    while (rt_pin_read(pin) && retry < 100)
-    {
-        retry++;
-        rt_hw_us_delay(1);
-    }
-
-    if(retry >= 100)
-    {
-        return CONNECT_FAILED;
-    }
-
-    retry = 0;
-    while (!rt_pin_read(pin) && retry < 100)
-    {
-        retry++;
-        rt_hw_us_delay(1);
-    };
-
-    if(retry >= 100)
-    {
-        return CONNECT_FAILED;
-    }
-
-    return CONNECT_SUCCESS;
-}
-
-static uint8_t dht11_read_bit(rt_base_t pin)
-{
-	uint8_t retry = 0;
-	while (rt_pin_read(pin) && retry < 100)
-    {
-        retry++;
-        rt_hw_us_delay(1);
-    }
-	retry = 0;
-
-	while (!rt_pin_read(pin) && retry < 100)
-    {
-        retry++;
-        rt_hw_us_delay(1);
-    }
-
-	rt_hw_us_delay(40);
-	if(rt_pin_read(pin))
-		return 1;
-    return 0;
-}
-
-static uint8_t dht11_read_byte(rt_base_t pin)
-{
-    uint8_t i, dat = 0;
-
-    for (i = 1; i <= 8; i++)
-    {
-        dat <<= 1;
-		dat |= dht11_read_bit(pin);
-    }
-
-    return dat;
-}
-
-static uint8_t dht11_read_Data(rt_base_t pin,uint8_t *temp,uint8_t *humi)
-{
-	uint8_t i, buf[5];
-	dht11_reset(pin);
-
-	if(dht11_check(pin) == 0)
-	{
-		for(i=0; i<5; i++) /* read 40 bits */
-		{
-			buf[i] = dht11_read_byte(pin);
-		}
-
-		if((buf[0] + buf[1] + buf[2] + buf[3]) == buf[4])
-		{
-			*humi = buf[0];
-			*temp = buf[2];
-		}
-	}
-    else
-    {
-        return 1;
-    }
-
-	return 0;	
-}
-
-uint8_t dht11_init(rt_base_t pin)
-{
-    uint8_t ret = 0;
-
-    dht11_reset(pin);
-    ret = dht11_check(pin);
-    if (ret != 0)
-    {
-        dht11_reset(pin);
-        ret = dht11_check(pin);
-    }
-
-    return ret;
-}
-
-int32_t dht11_get_temperature(rt_base_t pin)
-{
-    static int32_t temOLD = 0;
-    uint8_t humi=0, temp = 0;
-    int32_t temNEW;
-
-    dht11_read_Data(pin, &temp, &humi);
-
-    temNEW = (humi << 16)|(temp<<0);
-
-    if((temNEW != temOLD) && (temNEW !=0))
-    {
-        temOLD = temNEW;
-    }
-    return temOLD;
-}
 
 static rt_size_t dht11_polling_get_data(rt_sensor_t sensor, struct rt_sensor_data *data)
 {
@@ -220,6 +66,7 @@ static struct rt_sensor_ops sensor_ops =
 };
 
 static struct rt_sensor_device dht11_dev;
+
 int rt_hw_dht11_init(const char *name, struct rt_sensor_config *cfg)
 {
     rt_err_t result = RT_EOK;

--- a/sensor_dallas_dht11.c
+++ b/sensor_dallas_dht11.c
@@ -33,7 +33,7 @@
 #define RT_SENSOR_VENDOR_DALLAS (7u)
 #endif
 
-static rt_size_t dht11_polling_get_data(rt_sensor_t sensor, struct rt_sensor_data *data)
+static RT_SIZE_TYPE dht11_polling_get_data(rt_sensor_t sensor, struct rt_sensor_data *data)
 {
     rt_int32_t temperature_humidity;
     temperature_humidity = dht11_get_temperature((rt_base_t)sensor->config.intf.user_data);
@@ -42,7 +42,7 @@ static rt_size_t dht11_polling_get_data(rt_sensor_t sensor, struct rt_sensor_dat
     return 1;
 }
 
-static rt_size_t dht11_fetch_data(struct rt_sensor_device *sensor, void *buf, rt_size_t len)
+static RT_SIZE_TYPE dht11_fetch_data(struct rt_sensor_device *sensor, void *buf, rt_size_t len)
 {
     RT_ASSERT(buf);
 

--- a/sensor_dallas_dht11.h
+++ b/sensor_dallas_dht11.h
@@ -18,11 +18,12 @@
 
 #ifdef RT_USING_SENSOR
 
-#if RT_VER_NUM >= 0x50000
+#if defined(RT_VERSION_CHECK) && (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 0, 1))
     #include "drivers/sensor.h"
-    #define rt_size_t rt_ssize_t
+    #define RT_SIZE_TYPE   rt_ssize_t
 #else
     #include "sensor.h"
+    #define RT_SIZE_TYPE   rt_size_t
 #endif
 
 struct dht11_device

--- a/sensor_dallas_dht11.h
+++ b/sensor_dallas_dht11.h
@@ -15,6 +15,7 @@
 #define __SENSOR_DALLAS_DHT11_H__
 
 #include <rtthread.h>
+#include <rtdevice.h>
 
 #ifdef RT_USING_SENSOR
 
@@ -23,12 +24,6 @@
         #define RT_SIZE_TYPE   rt_ssize_t
     #else
         #define RT_SIZE_TYPE   rt_size_t
-    #endif
-
-    #if (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 1, 0))
-        #include "drivers/sensor.h"
-    #else
-        #include "sensor.h"
     #endif
 #endif
 

--- a/sensor_dallas_dht11.h
+++ b/sensor_dallas_dht11.h
@@ -18,12 +18,18 @@
 
 #ifdef RT_USING_SENSOR
 
-#if defined(RT_VERSION_CHECK) && (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 0, 1))
-    #include "drivers/sensor.h"
-    #define RT_SIZE_TYPE   rt_ssize_t
-#else
-    #include "sensor.h"
-    #define RT_SIZE_TYPE   rt_size_t
+#if defined(RT_VERSION_CHECK)
+    #if (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 0, 2))
+        #define RT_SIZE_TYPE   rt_ssize_t
+    #else
+        #define RT_SIZE_TYPE   rt_size_t
+    #endif
+
+    #if (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 1, 0))
+        #include "drivers/sensor.h"
+    #else
+        #include "sensor.h"
+    #endif
 #endif
 
 struct dht11_device

--- a/sensor_dallas_dht11.h
+++ b/sensor_dallas_dht11.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2018, RT-Thread Development Team
+ * Copyright (c) 2006-2024, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -7,17 +7,22 @@
  * Date           Author          Notes
  * 2019-08-01     LuoGong         the first version.
  * 2019-08-15     MurphyZhao      add lock and modify code style
+ * 2024-07-02     KurisaW         sensor mode separation
  *
  */
 
-#ifndef __DHT11_H__
-#define __DHT11_H__
+#ifndef __SENSOR_DALLAS_DHT11_H__
+#define __SENSOR_DALLAS_DHT11_H__
 
 #include <rtthread.h>
-#include "sensor.h"
 
-#define CONNECT_SUCCESS  0
-#define CONNECT_FAILED   1
+#ifdef RT_USING_SENSOR
+
+#if RT_VER_NUM >= 0x50000
+    #define rt_size_t rt_ssize_t
+#endif
+
+#include "drivers/sensor.h"
 
 struct dht11_device
 {
@@ -26,10 +31,8 @@ struct dht11_device
 };
 typedef struct dht11_device *dht11_device_t;
 
-uint8_t dht11_init(rt_base_t pin);
-int32_t dht11_get_temperature(rt_base_t pin);
 int rt_hw_dht11_init(const char *name, struct rt_sensor_config *cfg);
 
-#endif /* __DS18B20_H_ */
+#endif
 
-
+#endif /* __SENSOR_DALLAS_DHT11_H__ */

--- a/sensor_dallas_dht11.h
+++ b/sensor_dallas_dht11.h
@@ -19,10 +19,11 @@
 #ifdef RT_USING_SENSOR
 
 #if RT_VER_NUM >= 0x50000
+    #include "drivers/sensor.h"
     #define rt_size_t rt_ssize_t
+#else
+    #include "sensor.h"
 #endif
-
-#include "drivers/sensor.h"
 
 struct dht11_device
 {

--- a/sensor_dallas_dht11.h
+++ b/sensor_dallas_dht11.h
@@ -17,8 +17,6 @@
 #include <rtthread.h>
 #include <rtdevice.h>
 
-#ifdef RT_USING_SENSOR
-
 #if defined(RT_VERSION_CHECK)
     #if (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 0, 2))
         #define RT_SIZE_TYPE   rt_ssize_t
@@ -35,7 +33,5 @@ struct dht11_device
 typedef struct dht11_device *dht11_device_t;
 
 int rt_hw_dht11_init(const char *name, struct rt_sensor_config *cfg);
-
-#endif
 
 #endif /* __SENSOR_DALLAS_DHT11_H__ */


### PR DESCRIPTION
Adjust the structure of the sensor software package and divide it into two versions: Sensor framework driver and driver framework driver. The sensor version driver is used only after the user opens the sensor framework, and the driver examples of the two versions are provided.